### PR TITLE
Added support as cmdline provided plugin can be repaired by the tool

### DIFF
--- a/servicereportpkg/__init__.py
+++ b/servicereportpkg/__init__.py
@@ -18,6 +18,7 @@ from servicereportpkg.repair import Repair
 from servicereportpkg.validate import Validate
 from servicereportpkg.logger import setup_logger
 from servicereportpkg.report import generate_report
+from servicereportpkg.report import print_report
 from servicereportpkg.global_context import TOOL_NAME
 from servicereportpkg.logger import get_default_logger
 from servicereportpkg.utils import trigger_kernel_crash
@@ -55,6 +56,10 @@ def parse_commandline_args(args):
     parser.add_argument("-r", "--repair", action="store_true",
                         dest="repair", default=False,
                         help="Auto fix the incorrection configurations")
+    parser.add_argument("-rp", "--repair_plugin", dest="repair_plugin",
+                        nargs='+', default=None,
+                        help="fix the incorrection plugin configuration")
+
 
     parser.add_argument("-V", "--version", action="store_true",
                         dest="cmdarg_version", default=False,
@@ -116,7 +121,12 @@ def main():
     if cmd_opts.repair:
         Repair(cmd_opts).repair(validation_results)
         log.debug("Completed the repair.")
-
+    if cmd_opts.repair_plugin:
+        Repair(cmd_opts).repair_plugin(Validate(cmd_opts).validate(),cmd_opts.repair_plugin)
+        validation_results = Validate(cmd_opts).validate()
+        print_report(validation_results, cmd_opts.repair_plugin)
+        log.debug("Completed the repair of plugin/s %s." % cmd_opts.repair_plugin)
+        return 0
     generate_report(validation_results, cmd_opts)
 
     if cmd_opts.dump:

--- a/servicereportpkg/repair/__init__.py
+++ b/servicereportpkg/repair/__init__.py
@@ -11,7 +11,6 @@ from servicereportpkg.logger import get_default_logger
 from servicereportpkg.repair.plugins import RepairPluginHandler
 from servicereportpkg.logger import change_log_identifier
 
-
 class Repair(object):
     """Base class of all repair plugins"""
 
@@ -32,7 +31,6 @@ class Repair(object):
             # Find whether repair plugin is available or not
             if plugin in repair_plugins.keys():
                 repair_plugin_obj = repair_plugins[plugin]()
-
                 change_log_identifier(TOOL_NAME+ '.' + plugin, self.log)
 
                 for plugin_obj in validation_results[plugin]:
@@ -41,3 +39,15 @@ class Repair(object):
                 self.log.debug("Repair plugin is not available for %s", plugin)
 
         change_log_identifier(TOOL_NAME, self.log)
+    def repair_plugin(self,validation_results,plugins):
+        
+        repair_plugin=self.repair_plugin_handler.get_repair_plugins()
+        for plugin in plugins:
+            if plugin in repair_plugin.keys():
+                repair_plugin_obj = repair_plugin[plugin]()
+                for plugin_obj in validation_results[plugin]:
+                    repair_plugin_obj.repair(plugin_obj, plugin_obj.checks)
+            else:
+                self.log.debug("Repair plugin is not available for %s", plugin)
+        change_log_identifier(TOOL_NAME, self.log)
+

--- a/servicereportpkg/report.py
+++ b/servicereportpkg/report.py
@@ -83,3 +83,29 @@ def generate_report(validation_results, cmd_opts):
     """Generate the report based on the validation results"""
 
     print_report_on_console(validation_results, cmd_opts)
+
+def print_report(validation_results, plugins):
+
+    for plug in plugins:
+        for key in validation_results.keys():
+            if key == plug:
+                plugin_description = validation_results[key][0].get_description()
+                overall_status = True
+                for plugin in validation_results[key]:
+                    if not plugin.get_plugin_status():
+                        overall_status = False
+                        break
+
+                print("{0:52}{1}\n".format(plugin_description,
+                                           get_colored_status_msg(overall_status)))
+
+                for plugin_obj in validation_results[key]:
+                    for check in plugin_obj.checks:
+                        if check.get_note() is None:
+                            print("  {0:50}{1}".format(check.get_name(),
+                                                       get_colored_status_msg(check.get_status())))
+                        else:
+                            print("  {0:50}{1:20}{2}".format(check.get_name(),
+                                                             get_colored_status_msg(check.get_status()),
+                                                             check.get_note()))
+                print('\n')


### PR DESCRIPTION
This Patch add support that using -rp option user can
provide single or multiple plugin and based on if plugin
avilable it will repair and based on processing it print
plugin status

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>