### PR TITLE
Add "update-bls-cmdline" to update kernel command line in BLS snippets

### DIFF
--- a/servicereportpkg/utils.py
+++ b/servicereportpkg/utils.py
@@ -48,12 +48,11 @@ def get_package_classes(pkg_path, prefix):
     return pkg_classes
 
 
-def get_distro_name():
+def get_distro_name(distro_search_key = 'PRETTY_NAME'):
     """Finds the distro name from /etc/os-release and on success returns
     the distro name else empty string"""
 
     os_release = '/etc/os-release'
-    distro_search_key = 'PRETTY_NAME'
     log = get_default_logger()
 
     try:
@@ -135,7 +134,7 @@ def execute_command(command, sh=False):
 def find_package_manager():
     """Returns the package manager supported in the current system"""
 
-    distro = get_distro_name()
+    distro = get_distro_name('PRETTY_NAME')
     package_manager_options = \
         {"Fedora": {"command": "rpm", "search_option": "-qi",
                     "installer": "yum", "install_option": "install -y"},
@@ -343,7 +342,14 @@ def restart_service(service):
 
 
 def update_grub():
+    version = eval(get_distro_name('VERSION_ID').split()[0])
+    distro_name = get_distro_name('PRETTY_NAME').strip("")
     command = ["grub2-mkconfig", "-o", "/boot/grub2/grub.cfg"]
+    # Check if the distribution is RHEL and the version is 9.3 or greater
+    if "Red Hat" in distro_name:
+        major_version, minor_version = map(int, version.split('.'))
+        if (major_version == 9 and minor_version >= 3) or major_version > 9:
+            command = ["grub2-mkconfig", "-o", "/boot/grub2/grub.cfg", "--update-bls-cmdline"]
 
     return_code = execute_command(command)[0]
     if return_code == 0:

--- a/servicereportpkg/validate/schemes/schemes.py
+++ b/servicereportpkg/validate/schemes/schemes.py
@@ -12,7 +12,7 @@ from servicereportpkg.validate.schemes import Scheme
 from servicereportpkg.utils import get_service_processor
 from servicereportpkg.utils import get_distro_name, get_system_platform
 
-DISTRO = get_distro_name()
+DISTRO = get_distro_name(distro_search_key = 'PRETTY_NAME')
 
 
 class RHELScheme(Scheme):


### PR DESCRIPTION
RHEL 9.3 introduced some changes with the use of Boot Loader Specification (BLS) snippets. To update the kernel command line in BLS snippets according to GRUB_CMDLINE_LINUX, add the option "--update-bls-cmdline". 

For example :
grub2-mkconfig -o /boot/grub2/grub.cfg --update-bls-cmdline

Reference :

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/9.3_release_notes/index#new-features-boot-loader