### PR TITLE
[Service] Make the servicereport service dependent on the kdump service

### DIFF
--- a/service/servicereport.service
+++ b/service/servicereport.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=ServiceReport
-Wants=kdump.service
+After=kdump.service
+DefaultDependencies=no
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/servicereport -v
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Move the kdump.service from the Wants to the After directive. This will ensure that the servicereport service starts after kdump.service.

Additionally, remove all default service dependencies and keep the servicereport service active.