### PR TITLE
Ignoring the lines starting with "#"

### DIFF
--- a/servicereportpkg/utils.py
+++ b/servicereportpkg/utils.py
@@ -59,6 +59,9 @@ def get_distro_name():
     try:
         with open(os_release, 'r') as _file:
             for line in _file:
+                if line.startswith('#'):
+                    continue
+
                 (key, value) = line.split("=")
                 if key.startswith(distro_search_key):
                     return value.strip()


### PR DESCRIPTION
In few cases when there are lines starting with "#" in /etc/os-release file servicereport -v command is failing, so in this patch we are ignoring the lines starting with "#" to generate the output for servicereport -v.

Without the patch:
----------------------------
servicereport -v
servicereport 2.2.4

Traceback (most recent call last):
  File "/usr/bin/servicereport", line 15, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/servicereportpkg/__init__.py", line 143, in main
    validator = Validate(cmd_opts)
  File "/usr/lib/python3.13/site-packages/servicereportpkg/validate/__init__.py", line 26, in __init__
    self.scheme_handler = SchemeHandler()
                          ~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/servicereportpkg/validate/schemes/__init__.py", line 31, in __init__
    self.populate_schemes()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/servicereportpkg/validate/schemes/__init__.py", line 49, in populate_schemes
    for _class in get_package_classes(__path__, 'servicereportpkg.validate.schemes.'):
                  ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/servicereportpkg/utils.py", line 34, in get_package_classes
    module = importlib.import_module(name)
  File "/usr/lib64/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/usr/lib/python3.13/site-packages/servicereportpkg/validate/schemes/schemes.py", line 15, in <module>
    DISTRO = get_distro_name()
  File "/usr/lib/python3.13/site-packages/servicereportpkg/utils.py", line 62, in get_distro_name
    (key, value) = line.split("=")
    ^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)

With the patch:
-------------------------------
servicereport -v
servicereport 2.2.4

Daemon availability checks                          PASS

  rtas_errd                                         PASS
  irqbalance                                        PASS

Kdump configuration check                           FAIL

  Active dump                                       PASS
  Memory allocated for capture kernel               PASS
  Dump component in initial ramdisk                 FAIL
  Service status                                    FAIL
  Capture kernel load status                        FAIL
  kdump package                                     FAIL
  Kdump attributes in /etc/sysconfig/kdump          FAIL
  kexec package                                     PASS

Package availability check                          FAIL

  ppc64-diag                                        PASS
  irqbalance                                        PASS
  perf                                              FAIL
  supportutils                                      PASS
  powerpc-utils                                     PASS