### PR TITLE
[Spyre] overwrite the existing udev rules rather than appending.

### DIFF
--- a/servicereportpkg/repair/plugins/spyre_repair.py
+++ b/servicereportpkg/repair/plugins/spyre_repair.py
@@ -13,6 +13,7 @@ import re
 import shutil
 
 from servicereportpkg.check import Notes
+from servicereportpkg.utils import add_to_file
 from servicereportpkg.utils import append_to_file
 from servicereportpkg.utils import execute_command
 from servicereportpkg.utils import install_package
@@ -57,13 +58,48 @@ class SpyreRepair(RepairPlugin):
         else:
             user_mem_conf_check.set_note(Notes.FAIL_TO_FIX)
 
+    def verify_if_vfio_udev_rule_is_redundant(self, udev_rule):
+        """Verify if VFIO udev rule is Redundant"""
+
+        if udev_rule and ('SUBSYSTEM=="vfio"' in udev_rule):
+            splits = udev_rule.split(',')
+            length_splits = len(splits)
+            if length_splits  <= 3:
+                splits = [condition.strip() for condition in splits]
+                has_group = any('GROUP' in part for part in splits)
+                has_mode = any('MODE' in part for part in splits)
+                if ((length_splits==2 and (has_mode or has_group)) or
+                    (length_splits==3 and has_mode and has_group) or
+                    (length_splits==1)):
+                    return True
+        return False
+
     def fix_udev_rules_conf(self, plugin_obj, udev_rules_conf_check):
         """Fix VFIO udev rules"""
 
-        for config, val in udev_rules_conf_check.get_config_attributes().items():
-            if not val["status"]:
-                append_to_file(udev_rules_conf_check.get_file_path(),
-                               "\n"+config)
+        updated_lines = []
+        if not os.path.exists(udev_rules_conf_check.get_file_path()):
+            key = next(iter(udev_rules_conf_check.get_config_attributes()))
+            updated_lines.append(key + "\n")
+        else:
+            for config, val in udev_rules_conf_check.get_config_attributes().items():
+                if not val["status"]:
+                    try:
+                        with open(udev_rules_conf_check.get_file_path(), "r", encoding="utf-8") as file:
+                            lines = file.readlines()
+                        updated_lines.append(config+"\n")
+                        for line in lines:
+                            # if a vfio udev rule is redundant incorrect or old rule will be
+                            # removed
+                            if not self.verify_if_vfio_udev_rule_is_redundant(line.strip()):
+                                updated_lines.append(line)
+                    except FileNotFoundError:
+                        self.log.error("File not found : %s", udev_rules_conf_check.get_file_path())
+
+        updated_string = "".join(updated_lines)
+        add_to_file(udev_rules_conf_check.get_file_path(),
+                    updated_string)
+
         re_check = plugin_obj.check_udev_rule()
         if re_check.get_status():
             udev_rules_conf_check.set_status(True)

--- a/servicereportpkg/repair/plugins/spyre_repair.py
+++ b/servicereportpkg/repair/plugins/spyre_repair.py
@@ -117,26 +117,9 @@ class SpyreRepair(RepairPlugin):
     def fix_vfio_perm_check(self, plugin_obj, vfio_device_permission_check):
         """Fix VFIO device permission"""
 
-        vfio_dir = "/dev/vfio/"
-        group_name = 'sentient'
-        try:
-            gid = grp.getgrnam(group_name).gr_gid
-        except Exception as e:
-            self.log.error("Failed to get groupid of group: %s", group_name)
-            vfio_device_permission_check.set_note(Notes.FAIL_TO_FIX)
-            return
-
-        for name in os.listdir(vfio_dir):
-            full_path = vfio_dir + name
-            try:
-                mode = os.stat(full_path).st_mode
-                if stat.S_ISCHR(mode):
-                    os.chmod(full_path, 0o660)
-                    if os.stat(full_path).st_gid != gid:
-                        os.chown(full_path, -1, gid)
-
-            except Exception as e:
-                self.log.error("Failed to set %s file permission to 0o660", full_path)
+        execute_command(["udevadm", "control", "--reload-rules"])
+        execute_command(["udevadm", "trigger", "--subsystem-match=vfio"])
+        execute_command(["udevadm", "settle"])
 
         re_check = plugin_obj.check_vfio_access_permission()
         if re_check.get_status():

--- a/servicereportpkg/utils.py
+++ b/servicereportpkg/utils.py
@@ -405,6 +405,21 @@ def is_read_write_to_owner_group_users(file_path):
         return False
 
 
+def add_to_file(file_path, s):
+    """Add the given stirng to the file"""
+
+    log = get_default_logger()
+
+    try:
+        with open(file_path, "w", encoding="utf-8") as file:
+            file.write(s)
+
+        return True
+    except Exception as e:
+        log.debug("Failed to open file: %s, error: %s", file_path, e)
+        return False
+
+
 def append_to_file(file_path, s):
     """Append the given stirng to the file"""
 

--- a/servicereportpkg/validate/plugins/spyre.py
+++ b/servicereportpkg/validate/plugins/spyre.py
@@ -265,7 +265,10 @@ class Spyre(Plugin, Scheme):
             try:
                 ret = True
                 mode = os.stat(full_path).st_mode
-                if stat.S_ISCHR(mode):
+                # /dev/vfio/vfio file permissions doesn't need to be
+                # validated as its permissons doesnt affect
+                # the vfio spyre card permissions
+                if stat.S_ISCHR(mode) and name != 'vfio':
                     if os.stat(full_path).st_gid != gid:
                         ret = False
                     ret = ret & is_read_write_to_owner_group_users(full_path)

--- a/servicereportpkg/validate/plugins/spyre.py
+++ b/servicereportpkg/validate/plugins/spyre.py
@@ -106,7 +106,7 @@ class Spyre(Plugin, Scheme):
     def check_udev_rule(self):
         """VFIO udev rules configuration"""
 
-        vfio_udev = "SUBSYSTEM==\"vfio\", GROUP=\"sentient\", MODE=\"0660\""
+        vfio_udev = "SUBSYSTEM==\"vfio\", GROUP:=\"sentient\", MODE:=\"0660\""
         config_file = "/etc/udev/rules.d/95-vfio-3.rules"
 
         conf_check = ConfigurationFileCheck(self.check_udev_rule.__doc__,
@@ -117,8 +117,17 @@ class Spyre(Plugin, Scheme):
             with open(config_file, "r", encoding="utf-8") as file:
                 for line in file:
                     line = line.strip()
+                    if not line and line.startswith("#"):
+                        continue
                     if line == vfio_udev:
                         status = True
+                        break
+                    # If incorrect vfio rules exists in file which
+                    # will persist and overwrites the correct config
+                    # which present later validation fails.
+                    elif ('SUBSYSTEM=="vfio"' in line and
+                        ("GROUP:=" in line or "MODE:=" in line)):
+                        status = False
                         break
         except FileNotFoundError:
             self.log.error("File not found : %s", config_file)


### PR DESCRIPTION
when udev rule already exists for a subsytem, rather than overwriting the existing udev rule, it appends the new rule at the end.

the fix here overwrites the existing rules th if rule for susbstem already exists, or appends the new rule if it doesnt exists.