### PR TITLE
 Run spyre checks only on RHEL and Fedora

### DIFF
--- a/servicereportpkg/repair/plugins/spyre_repair.py
+++ b/servicereportpkg/repair/plugins/spyre_repair.py
@@ -333,17 +333,19 @@ class SpyreRepair(RepairPlugin):
         elif vfio_device_permission_check.get_status() is False:
             self.fix_vfio_perm_check(plugin_obj, vfio_device_permission_check)
 
-        sos_package_check = check_dir["sos package"]
-        if sos_package_check.get_status() is False:
-            self.fix_sos_package(plugin_obj, sos_package_check)
-        elif sos_package_check.get_status is None:
-            sos_package_check.set_note(Notes.NOT_FIXABLE)
+        if "sos package" in check_dir.keys():
+            sos_package_check = check_dir["sos package"]
+            if sos_package_check.get_status() is False:
+                self.fix_sos_package(plugin_obj, sos_package_check)
+            elif sos_package_check.get_status is None:
+                sos_package_check.set_note(Notes.NOT_FIXABLE)
 
-        sos_config_check = check_dir["sos config"]
-        # if sos package is not intalled, not much can be done
-        if not sos_package_check.get_status():
-            sos_config_check.set_note(Notes.NOT_FIXABLE)
-        elif sos_config_check.get_status() is False:
-            self.fix_sos_config(plugin_obj, sos_config_check)
-        elif sos_config_check.get_status is None:
-            sos_config_check.set_note(Notes.NOT_FIXABLE)
+        if "sos config" in check_dir.keys():
+            sos_config_check = check_dir["sos config"]
+            # if sos package is not intalled, not much can be done
+            if not sos_package_check.get_status():
+                sos_config_check.set_note(Notes.NOT_FIXABLE)
+            elif sos_config_check.get_status() is False:
+                self.fix_sos_config(plugin_obj, sos_config_check)
+            elif sos_config_check.get_status is None:
+                sos_config_check.set_note(Notes.NOT_FIXABLE)

--- a/servicereportpkg/validate/plugins/spyre.py
+++ b/servicereportpkg/validate/plugins/spyre.py
@@ -20,13 +20,13 @@ from servicereportpkg.check import FilesCheck
 from servicereportpkg.utils import is_package_installed
 from servicereportpkg.check import ConfigurationFileCheck
 from servicereportpkg.utils import is_read_write_to_owner_group_users
+from servicereportpkg.validate.schemes.schemes import FedoraScheme, RHELScheme
 
 
-class Spyre(Plugin, Scheme):
+class Spyre(object):
     """Spyre configuration checks"""
 
     def __init__(self):
-        Plugin.__init__(self)
         self.name = Spyre.__name__
         self.description = Spyre.__doc__
 
@@ -290,6 +290,12 @@ class Spyre(Plugin, Scheme):
         perm_check.set_status(status)
         return perm_check
 
+class SpyreSoS(Spyre):
+    """Spyre SoS configuration check"""
+
+    def __init__(self):
+        Spyre.__init__(self)
+
     def check_sos_package(self):
         """sos package"""
 
@@ -355,3 +361,17 @@ class Spyre(Plugin, Scheme):
 
         sos_config_check.set_status(status)
         return sos_config_check
+
+class SpyreFedora(SpyreSoS, Plugin, FedoraScheme):
+    """Spyre Fedora configuration checks"""
+
+    def __init__(self):
+        Plugin.__init__(self)
+        SpyreSoS.__init__(self)
+
+class SpyreRHEL(SpyreSoS, Plugin, RHELScheme):
+    """Spyre RHEL configuration checks"""
+
+    def __init__(self):
+        Plugin.__init__(self)
+        SpyreSoS.__init__(self)


### PR DESCRIPTION
All Spyre checks are now gated by the RHEL and Fedora schemes
