### PR TITLE
[kdump] Fix TypeError in kdump component check

### DIFF
--- a/servicereportpkg/validate/plugins/kdump.py
+++ b/servicereportpkg/validate/plugins/kdump.py
@@ -520,12 +520,14 @@ class KdumpSuSE(Kdump, Plugin, SuSEScheme):
             if return_code is None:
                 continue
 
-            if self.dump_comp_name not in str(stdout):
-                continue
+            for comp in self.dump_comp_name:
+                if comp in str(stdout):
+                    status = True
+                    self.log.debug("%s component found in %s", comp, initrd)
+                    break
 
-            status = True
-            self.log.debug("%s component found in %s", self.dump_comp_name, initrd)
-            break
+            if status:
+                break
 
         return Check(self.check_dump_component_in_initrd.__doc__,
                      status)


### PR DESCRIPTION
The check_dump_component_in_initrd() method was attempting to use the 'in' operator with a list (self.dump_comp_name) as the left operand and a string as the right operand, which causes a TypeError: "'in <string>' requires string as left operand, not list"

This fix iterates through each component name in the list and checks if any of them exist in the stdout string. When a component is found, it sets status to True and breaks from both loops.